### PR TITLE
Chore: Cxpui51 - Landing pages -"whats included" section

### DIFF
--- a/src/components/LandingPage/Alerts.js
+++ b/src/components/LandingPage/Alerts.js
@@ -1,6 +1,4 @@
 import { PageTools } from '@newrelic/gatsby-theme-newrelic';
-import { quickstart } from '../../types';
-import PageLayout from '../PageLayout';
 import QuickstartAlerts from '../../components/QuickstartAlerts';
 import EmptyTab from '../../components/EmptyTab';
 import { css } from '@emotion/react';

--- a/src/components/LandingPage/Alerts.js
+++ b/src/components/LandingPage/Alerts.js
@@ -1,0 +1,35 @@
+import { PageTools } from '@newrelic/gatsby-theme-newrelic';
+import { quickstart } from '../../types';
+import PageLayout from '../PageLayout';
+import QuickstartAlerts from '../../components/QuickstartAlerts';
+import EmptyTab from '../../components/EmptyTab';
+import { css } from '@emotion/react';
+
+const Alerts = ({ quickstart }) => {
+
+    return (
+        <PageTools.Section>
+            <h2>Alerts &nbsp;
+                <div
+                    css={css`
+                        display: inline-block;
+                        background: #D6D6D6;
+                    `}
+                >
+                    {quickstart.alerts.length}</div>
+            </h2>
+
+            {quickstart.alerts?.length > 0 ? (
+                <QuickstartAlerts quickstart={quickstart} />
+            ) : (
+                <EmptyTab
+                    quickstartUrl={quickstart.packUrl}
+                    quickstartName={quickstart.title}
+                    tabName="alerts"
+                />
+            )}
+        </PageTools.Section>
+    )
+};
+
+export default Alerts;

--- a/src/components/LandingPage/Dashboards.js
+++ b/src/components/LandingPage/Dashboards.js
@@ -6,12 +6,15 @@ import EmptyTab from '../../components/EmptyTab';
 import { css } from '@emotion/react';
 
 const Dashboards = ({ quickstart }) => {
-    const quickstartUrl = quickstart.packUrl || QUICKSTARTS_REPO;
 
     return (
         <PageTools.Section>
-            <h1>What's included?</h1><br />
-            <h2>Dashboard &nbsp;
+            <h1>
+                What's included?
+            </h1>
+            <br />
+            <h2>Dashboard
+                &nbsp;
                 <div
                     css={css`
                         display: inline-block;

--- a/src/components/LandingPage/Dashboards.js
+++ b/src/components/LandingPage/Dashboards.js
@@ -1,0 +1,41 @@
+import { PageTools } from '@newrelic/gatsby-theme-newrelic';
+import { quickstart } from '../../types';
+import PageLayout from '../PageLayout';
+import QuickstartDashboards from '../../components/QuickstartDashboards';
+import EmptyTab from '../../components/EmptyTab';
+import { css } from '@emotion/react';
+
+const Dashboards = ({ quickstart }) => {
+    const quickstartUrl = quickstart.packUrl || QUICKSTARTS_REPO;
+
+    return (
+        <PageTools.Section>
+            <h1>What's included?</h1><br />
+            <h2>Dashboard &nbsp;
+                <div
+                    css={css`
+                        display: inline-block;
+                        background: #D6D6D6;
+                    `}
+                >
+                    {quickstart.dashboards.length}</div>
+            </h2>
+
+            {quickstart.dashboards?.length > 0 ? (
+                <QuickstartDashboards quickstart={quickstart} />
+            ) : (
+                <EmptyTab
+                    quickstartUrl={quickstart.packUrl}
+                    quickstartName={quickstart.title}
+                    tabName="dashboards"
+                />
+            )}
+        </PageTools.Section>
+    );
+};
+
+Dashboards.propTypes = {
+    quickstart: quickstart.isRequired,
+};
+
+export default Dashboards;

--- a/src/components/LandingPage/Dashboards.js
+++ b/src/components/LandingPage/Dashboards.js
@@ -1,6 +1,5 @@
 import { PageTools } from '@newrelic/gatsby-theme-newrelic';
 import { quickstart } from '../../types';
-import PageLayout from '../PageLayout';
 import QuickstartDashboards from '../../components/QuickstartDashboards';
 import EmptyTab from '../../components/EmptyTab';
 import { css } from '@emotion/react';
@@ -10,7 +9,7 @@ const Dashboards = ({ quickstart }) => {
     return (
         <PageTools.Section>
             <h1>
-                What's included?
+                What&apos;s included?
             </h1>
             <br />
             <h2>Dashboard

--- a/src/components/LandingPage/DataSources.js
+++ b/src/components/LandingPage/DataSources.js
@@ -1,0 +1,34 @@
+import QuickstartDataSources from '../../components/QuickstartDataSources';
+import { PageTools } from '@newrelic/gatsby-theme-newrelic';
+import { quickstart } from '../../types';
+import PageLayout from '../PageLayout';
+import EmptyTab from '../../components/EmptyTab';
+import { css } from '@emotion/react';
+
+const DataSources = ({ quickstart }) => {
+    return (
+        <PageTools.Section>
+            <h2>Data Sources &nbsp;
+                <div
+                    css={css`
+                        display: inline-block;
+                        background: #D6D6D6;
+                    `}
+                >
+                    {quickstart.documentation.length}</div>
+            </h2>
+
+            {quickstart.documentation?.length > 0 ? (
+                <QuickstartDataSources quickstart={quickstart} />
+            ) : (
+                <EmptyTab
+                    quickstartUrl={quickstart.packUrl}
+                    quickstartName={quickstart.title}
+                    tabName="data sources"
+                />
+            )}
+        </PageTools.Section>
+    )
+};
+
+export default DataSources;

--- a/src/components/LandingPage/DataSources.js
+++ b/src/components/LandingPage/DataSources.js
@@ -1,7 +1,5 @@
 import QuickstartDataSources from '../../components/QuickstartDataSources';
 import { PageTools } from '@newrelic/gatsby-theme-newrelic';
-import { quickstart } from '../../types';
-import PageLayout from '../PageLayout';
 import EmptyTab from '../../components/EmptyTab';
 import { css } from '@emotion/react';
 

--- a/src/components/QuickstartDescription.js
+++ b/src/components/QuickstartDescription.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { css } from '@emotion/react';
+import { quickstart } from '../types';
+import Markdown from './Markdown';
+
+const allowedElements = [
+  'h1',
+  'h2',
+  'h3',
+  'ol',
+  'ul',
+  'li',
+  'p',
+  'blockquote',
+  'code',
+  'a',
+  'strong',
+  'em',
+  'hr',
+];
+
+const QuickstartDescription = ({ quickstart }) => {
+  return (
+    <>
+      {quickstart.description && (
+        <div
+          css={css`
+            h1,
+            h2,
+            h3 {
+              margin: 1em 0 0.25em 0;
+            }
+            p,
+            pre {
+              margin-left: 1em;
+            }
+            h1,
+            h2 {
+              font-size: 1.5em;
+              font-weight: 600;
+            }
+            h3 {
+              font-size: 1.2em;
+            }
+          `}
+        >
+          <Markdown
+            skipHtml
+            allowedElements={allowedElements}
+            css={css`
+              margin: 2em 0;
+            `}
+          >
+            {quickstart.description}
+          </Markdown>
+        </div>
+      )}
+    </>
+  );
+};
+
+QuickstartDescription.propTypes = {
+  quickstart: quickstart.isRequired,
+};
+
+export default QuickstartDescription;

--- a/src/components/QuickstartHowToUse.js
+++ b/src/components/QuickstartHowToUse.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import {
+  Link,
+  PageTools,
+  RelatedResources,
+} from '@newrelic/gatsby-theme-newrelic';
+import { css } from '@emotion/react';
+import { quickstart } from '../types';
+import {
+  LOGIN_LINK,
+  SIGNUP_LINK,
+} from '../data/constants';
+import SupportSection from '../components/SupportSection';
+
+const QuickstartHowToUse = ({
+  quickstart,
+  trackQuickstart,
+  tessenSupportTrack,
+}) => {
+  return (
+    <>
+      <PageTools.Section>
+        <div
+          css={css`
+            background-color: var(--divider-color);
+            // position: absolute;
+            top: 0;
+            left: 0;
+            padding: 1rem;
+            padding-top: 0.5rem;
+            height: 2.5rem;
+            width: 100%;
+          `}
+        >
+          <PageTools.Title>How to use this quickstart</PageTools.Title>
+        </div>
+        <ol
+          css={css`
+            margin-top: 2.5rem;
+          `}
+        >
+          <li>
+            <Link
+              to={SIGNUP_LINK}
+              onClick={trackQuickstart(
+                'QuickstartDetailsSignUpClick',
+                quickstart
+              )}
+            >
+              Sign Up
+            </Link>{' '}
+            for a free New Relic account or{' '}
+            <Link
+              to={LOGIN_LINK}
+              onClick={trackQuickstart(
+                'QuickstartDetailsLoginClick',
+                quickstart
+              )}
+            >
+              Log In
+            </Link>{' '}
+            to your existing account.
+          </li>
+          <li>Click the green install button above.</li>
+          <li>
+            Install the quickstart to get started or improve how you monitor
+            your environment. They’re filled with pre-built resources like
+            dashboards, instrumentation, and alerts.
+          </li>
+        </ol>
+      </PageTools.Section>
+
+      <PageTools.Section>
+        <PageTools.Title>Authors</PageTools.Title>
+        <p>{quickstart.authors.join(', ')}</p>
+      </PageTools.Section>
+      <PageTools.Section>
+        <PageTools.Title>Support</PageTools.Title>
+        <SupportSection
+          supportLevel={quickstart.level}
+          onClick={tessenSupportTrack(quickstart)}
+        />
+      </PageTools.Section>
+      <PageTools.Section>
+        <RelatedResources
+          css={css`
+            padding: 0;
+          `}
+          resources={quickstart.relatedResources}
+        />
+      </PageTools.Section>
+    </>
+  );
+};
+
+QuickstartHowToUse.propTypes = {
+  quickstart: quickstart.isRequired,
+};
+
+export default QuickstartHowToUse;

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -3,15 +3,11 @@ import {
   Icon,
   Layout,
   Link,
-  PageTools,
-  RelatedResources,
   useTessen,
 } from '@newrelic/gatsby-theme-newrelic';
 import {
-  LOGIN_LINK,
   QUICKSTARTS_REPO,
-  SHIELD_LEVELS,
-  SIGNUP_LINK,
+  SHIELD_LEVELS
 } from '../data/constants';
 import React, { useEffect, useState } from 'react';
 
@@ -24,12 +20,11 @@ import PropTypes from 'prop-types';
 import QuickstartAlerts from '../components/QuickstartAlerts';
 import QuickstartDashboards from '../components/QuickstartDashboards';
 import QuickstartDataSources from '../components/QuickstartDataSources';
-import QuickstartOverview from '../components/QuickstartOverview';
-import SupportSection from '../components/SupportSection';
-import Tabs from '../components/Tabs';
 import { css } from '@emotion/react';
 import { graphql } from 'gatsby';
 import { quickstart } from '../types';
+import QuickstartDescription from '../components/QuickstartDescription';
+import QuickstartHowToUse from '../components/QuickstartHowToUse';
 
 const QuickstartDetails = ({ data, location }) => {
 
@@ -65,16 +60,6 @@ const QuickstartDetails = ({ data, location }) => {
       quickstartUrl: quickstart.packUrl,
     });
 
-  const tessenTabTrack = (action, quickstart) => (id, count) => {
-    tessen.track({
-      eventName: 'instantObservability',
-      category: action,
-      QuickstartTabState: id,
-      QuickstartTabCount: count,
-      quickstartName: quickstart.name,
-      quickstartId: quickstart.id,
-    });
-  };
   const tessenSupportTrack = (quickstart) => (action) => {
     tessen.track({
       eventName: 'instantObservability',
@@ -127,11 +112,10 @@ const QuickstartDetails = ({ data, location }) => {
         meta={quickStartMeta}
       />
       <Breadcrumbs segments={breadcrumbs} />
-      <Tabs>
         <PageLayout
           type={PageLayout.TYPE.RELATED_CONTENT_TABS}
           css={css`
-            grid-template-columns: minmax(0, 1fr) 360px;
+            grid-template-columns: minmax(0, 1fr);
             margin-top: 1rem;
           `}
         >
@@ -261,194 +245,71 @@ const QuickstartDetails = ({ data, location }) => {
               </Button>
             </div>
           </PageLayout.Header>
-          <Tabs.Bar
-            css={css`
-              grid-column: 1/3;
-              box-sizing: border-box;
-              padding-right: 30%;
-              @media (max-width: 1240px) {
-                padding: 0;
-              }
-              @media (max-width: 760px) {
-                flex-wrap: wrap;
-              }
-            `}
-          >
-            <Tabs.BarItem id="overview">Overview</Tabs.BarItem>
-            <Tabs.BarItem
-              id="dashboards"
-              count={quickstart.dashboards?.length ?? 0}
-              onClick={tessenTabTrack(`QuickstartTabToggle`, quickstart)}
-            >
-              Dashboards
-            </Tabs.BarItem>
-            <Tabs.BarItem
-              id="alerts"
-              count={quickstart.alerts?.length ?? 0}
-              onClick={tessenTabTrack(`QuickstartTabToggle`, quickstart)}
-            >
-              Alerts
-            </Tabs.BarItem>
-            <Tabs.BarItem
-              id="data-sources"
-              count={
-                (quickstart.instrumentation?.length ?? 0) +
-                (quickstart.documentation?.length ?? 0)
-              }
-              onClick={tessenTabTrack(`QuickstartTabToggle`, quickstart)}
-            >
-              Data sources
-            </Tabs.BarItem>
-          </Tabs.Bar>
+
           <Layout.Content>
-            <Tabs.Pages>
-              <Tabs.Page id="overview">
-                <QuickstartOverview quickstart={quickstart} />
-              </Tabs.Page>
-              <Tabs.Page id="dashboards">
-                {quickstart.dashboards?.length > 0 ? (
-                  <QuickstartDashboards quickstart={quickstart} />
-                ) : (
-                  <EmptyTab
-                    quickstartUrl={quickstart.packUrl}
-                    quickstartName={quickstart.title}
-                    tabName="dashboards"
-                  />
-                )}
-              </Tabs.Page>
-              <Tabs.Page id="alerts">
-                {quickstart.alerts?.length > 0 ? (
-                  <QuickstartAlerts quickstart={quickstart} />
-                ) : (
-                  <EmptyTab
-                    quickstartUrl={quickstart.packUrl}
-                    quickstartName={quickstart.title}
-                    tabName="alerts"
-                  />
-                )}
-              </Tabs.Page>
-              <Tabs.Page id="data-sources">
-                {quickstart.documentation?.length > 0 ? (
-                  <QuickstartDataSources quickstart={quickstart} />
-                ) : (
-                  <EmptyTab
-                    quickstartUrl={quickstart.packUrl}
-                    quickstartName={quickstart.title}
-                    tabName="data sources"
-                  />
-                )}
-              </Tabs.Page>
-            </Tabs.Pages>
+
+          {/* What's included section here */}
+
+            <h2> What&apos;s included </h2>
+            <div
+              css={css`
+                display: grid;
+                grid-gap: 1rem;
+                grid-template-columns: repeat(1, 1fr);
+
+                @media (max-width: 1180px) {
+                  grid-template-columns: repeat(1, 1fr);
+                }
+              `}
+            >
+              <h3>Dashboard</h3>
+              {quickstart.dashboards?.length > 0 ? (
+                <QuickstartDashboards quickstart={quickstart} />
+              ) : (
+                <EmptyTab
+                  quickstartUrl={quickstart.packUrl}
+                  quickstartName={quickstart.title}
+                  tabName="dashboards"
+                />
+              )}
+              <h3>Alerts</h3>
+              {quickstart.alerts?.length > 0 ? (
+                <QuickstartAlerts quickstart={quickstart} />
+              ) : (
+                <EmptyTab
+                  quickstartUrl={quickstart.packUrl}
+                  quickstartName={quickstart.title}
+                  tabName="alerts"
+                />
+              )}
+              <h3>Data source</h3>
+              {quickstart.documentation?.length > 0 ? (
+                <QuickstartDataSources quickstart={quickstart} />
+              ) : (
+                <EmptyTab
+                  quickstartUrl={quickstart.packUrl}
+                  quickstartName={quickstart.title}
+                  tabName="data sources"
+                />
+              )}
+            </div>
+
+          {/* Quickstart description here */}
+            <QuickstartDescription quickstart={quickstart} />
+
+          {/* How to use this quickstart here */}
+          <QuickstartHowToUse
+            quickstart={quickstart}
+            trackQuickstart={trackQuickstart}
+            tessenSupportTrack={tessenSupportTrack}
+          />
+
+          {/* Get started component here */}
+
+
           </Layout.Content>
-          <Layout.PageTools
-            css={css`
-              p,
-              li {
-                font-size: 0.85rem;
-              }
-              max-height: 100%;
-              @media (min-width: 1240px) {
-                width: 320px;
-                justify-self: flex-end;
-              }
-            `}
-          >
-            <PageTools.Section>
-              <div
-                css={css`
-                  background-color: var(--divider-color);
-                  position: absolute;
-                  top: 0;
-                  left: 0;
-                  padding: 1rem;
-                  padding-top: 0.5rem;
-                  height: 2.5rem;
-                  width: 100%;
-                `}
-              >
-                <PageTools.Title>How to use this quickstart</PageTools.Title>
-              </div>
-              <ol
-                css={css`
-                  margin-top: 2.5rem;
-                `}
-              >
-                <li>
-                  <Link
-                    to={SIGNUP_LINK}
-                    onClick={trackQuickstart(
-                      'QuickstartDetailsSignUpClick',
-                      quickstart
-                    )}
-                  >
-                    Sign Up
-                  </Link>{' '}
-                  for a free New Relic account or{' '}
-                  <Link
-                    to={LOGIN_LINK}
-                    onClick={trackQuickstart(
-                      'QuickstartDetailsLoginClick',
-                      quickstart
-                    )}
-                  >
-                    Log In
-                  </Link>{' '}
-                  to your existing account.
-                </li>
-                <li>Click the green install button above.</li>
-                <li>
-                  Install the quickstart to get started or improve how you
-                  monitor your environment. They’re filled with pre-built
-                  resources like dashboards, instrumentation, and alerts.
-                </li>
-              </ol>
-            </PageTools.Section>
-            <aside
-              data-swiftype-index={false}
-              css={css`
-                border-bottom: 1px solid var(--divider-color);
-              `}
-            />
-            <PageTools.Section>
-              <PageTools.Title>Authors</PageTools.Title>
-              <p>{quickstart.authors.join(', ')}</p>
-            </PageTools.Section>
-            <aside
-              data-swiftype-index={false}
-              css={css`
-                border-bottom: 1px solid var(--divider-color);
-              `}
-            />
-            <PageTools.Section>
-              <PageTools.Title>Support</PageTools.Title>
-              <SupportSection
-                supportLevel={quickstart.level}
-                onClick={tessenSupportTrack(quickstart)}
-              />
-            </PageTools.Section>
-            <aside
-              data-swiftype-index={false}
-              css={css`
-                border-bottom: 1px solid var(--divider-color);
-              `}
-            />
-            <PageTools.Section>
-              <RelatedResources
-                css={css`
-                  padding: 0;
-                `}
-                resources={quickstart.relatedResources}
-              />
-            </PageTools.Section>
-            <aside
-              data-swiftype-index={false}
-              css={css`
-                border-bottom: 1px solid var(--divider-color);
-              `}
-            />
-          </Layout.PageTools>
+
         </PageLayout>
-      </Tabs>
     </>
   );
 };

--- a/src/templates/QuickstartDetails.js
+++ b/src/templates/QuickstartDetails.js
@@ -25,6 +25,9 @@ import { graphql } from 'gatsby';
 import { quickstart } from '../types';
 import QuickstartDescription from '../components/QuickstartDescription';
 import QuickstartHowToUse from '../components/QuickstartHowToUse';
+import Dashboards from '../components/LandingPage/Dashboards';
+import Alerts from '../components/LandingPage/Alerts';
+import DataSources from '../components/LandingPage/DataSources';
 
 const QuickstartDetails = ({ data, location }) => {
 
@@ -74,7 +77,7 @@ const QuickstartDetails = ({ data, location }) => {
     const img = new Image();
     img.src = url;
     const { width, height } = await new Promise(resolve => {
-      img.onload = function() {
+      img.onload = function () {
         resolve({
           width: this.width,
           height: this.height
@@ -112,29 +115,29 @@ const QuickstartDetails = ({ data, location }) => {
         meta={quickStartMeta}
       />
       <Breadcrumbs segments={breadcrumbs} />
-        <PageLayout
-          type={PageLayout.TYPE.RELATED_CONTENT_TABS}
-          css={css`
+      <PageLayout
+        type={PageLayout.TYPE.RELATED_CONTENT_TABS}
+        css={css`
             grid-template-columns: minmax(0, 1fr);
             margin-top: 1rem;
           `}
-        >
-          <PageLayout.Header
-            title={quickstart.title}
-            icon={
-              SHIELD_LEVELS.includes(quickstart.level) && (
-                <Icon
-                  name="nr-check-shield"
-                  size="50%"
-                  css={css`
+      >
+        <PageLayout.Header
+          title={quickstart.title}
+          icon={
+            SHIELD_LEVELS.includes(quickstart.level) && (
+              <Icon
+                name="nr-check-shield"
+                size="50%"
+                css={css`
                     width: 0.75rem;
                     height: 1rem;
                     margin-left: 0.5rem;
                   `}
-                />
-              )
-            }
-            css={css`
+              />
+            )
+          }
+          css={css`
               border-bottom: none;
               display: grid;
               grid-column-gap: 1rem;
@@ -171,13 +174,13 @@ const QuickstartDetails = ({ data, location }) => {
                 box-shadow: none;
               }
             `}
-          >
-            {quickstart.logoUrl && (
-              <img
-                style={imgStyle}
-                src={quickstart.logoUrl}
-                alt={quickstart.title}
-                css={css`
+        >
+          {quickstart.logoUrl && (
+            <img
+              style={imgStyle}
+              src={quickstart.logoUrl}
+              alt={quickstart.title}
+              css={css`
                   max-height: 100%;
                   max-width: 12rem;
                   width: 100%;
@@ -193,11 +196,11 @@ const QuickstartDetails = ({ data, location }) => {
                     display: none;
                   }
                 `}
-              />
-            )}
-            {quickstart.summary && (
-              <div
-                css={css`
+            />
+          )}
+          {quickstart.summary && (
+            <div
+              css={css`
                   grid-area: summ;
                   max-width: 50vw;
 
@@ -205,12 +208,12 @@ const QuickstartDetails = ({ data, location }) => {
                     max-width: 100%;
                   }
                 `}
-              >
-                {quickstart.summary}
-              </div>
-            )}
-            <div
-              css={css`
+            >
+              {quickstart.summary}
+            </div>
+          )}
+          <div
+            css={css`
                 grid-area: cta;
                 display: flex;
                 justify-content: center;
@@ -220,39 +223,36 @@ const QuickstartDetails = ({ data, location }) => {
                   align-items: stretch;
                 }
               `}
-            >
-              <InstallButton quickstart={quickstart} location={location} />
-              <Button
-                as={Link}
-                variant={Button.VARIANT.OUTLINE}
-                to={quickstartUrl}
-                rel="noopener noreferrer"
-                css={css`
+          >
+            <InstallButton quickstart={quickstart} location={location} />
+            <Button
+              as={Link}
+              variant={Button.VARIANT.OUTLINE}
+              to={quickstartUrl}
+              rel="noopener noreferrer"
+              css={css`
                   margin: 0 0 0 0.5rem;
                   @media (max-width: 760px) {
                     margin: 1rem 0 0 0;
                   }
                 `}
-                onClick={trackQuickstart('QuickstartViewRepoClick', quickstart)}
-              >
-                <Icon
-                  name="fe-github"
-                  css={css`
+              onClick={trackQuickstart('QuickstartViewRepoClick', quickstart)}
+            >
+              <Icon
+                name="fe-github"
+                css={css`
                     margin-right: 7px;
                   `}
-                />
-                View repo
-              </Button>
-            </div>
-          </PageLayout.Header>
+              />
+              View repo
+            </Button>
+          </div>
+        </PageLayout.Header>
 
-          <Layout.Content>
-
+        <Layout.Content>
           {/* What's included section here */}
-
-            <h2> What&apos;s included </h2>
-            <div
-              css={css`
+          <div
+            css={css`
                 display: grid;
                 grid-gap: 1rem;
                 grid-template-columns: repeat(1, 1fr);
@@ -261,41 +261,14 @@ const QuickstartDetails = ({ data, location }) => {
                   grid-template-columns: repeat(1, 1fr);
                 }
               `}
-            >
-              <h3>Dashboard</h3>
-              {quickstart.dashboards?.length > 0 ? (
-                <QuickstartDashboards quickstart={quickstart} />
-              ) : (
-                <EmptyTab
-                  quickstartUrl={quickstart.packUrl}
-                  quickstartName={quickstart.title}
-                  tabName="dashboards"
-                />
-              )}
-              <h3>Alerts</h3>
-              {quickstart.alerts?.length > 0 ? (
-                <QuickstartAlerts quickstart={quickstart} />
-              ) : (
-                <EmptyTab
-                  quickstartUrl={quickstart.packUrl}
-                  quickstartName={quickstart.title}
-                  tabName="alerts"
-                />
-              )}
-              <h3>Data source</h3>
-              {quickstart.documentation?.length > 0 ? (
-                <QuickstartDataSources quickstart={quickstart} />
-              ) : (
-                <EmptyTab
-                  quickstartUrl={quickstart.packUrl}
-                  quickstartName={quickstart.title}
-                  tabName="data sources"
-                />
-              )}
-            </div>
+          >
+            <Dashboards quickstart={quickstart} />
+            <Alerts quickstart={quickstart} />
+            <DataSources quickstart={quickstart} />
+          </div>
 
           {/* Quickstart description here */}
-            <QuickstartDescription quickstart={quickstart} />
+          <QuickstartDescription quickstart={quickstart} />
 
           {/* How to use this quickstart here */}
           <QuickstartHowToUse
@@ -307,9 +280,9 @@ const QuickstartDetails = ({ data, location }) => {
           {/* Get started component here */}
 
 
-          </Layout.Content>
+        </Layout.Content>
 
-        </PageLayout>
+      </PageLayout>
     </>
   );
 };


### PR DESCRIPTION
JIRA: https://newrelic.atlassian.net/browse/CXPUI-51
Description:  Landing pages -"whats included" section
Fix: Removed tab section and "how to quickstart section" and added "What's included" section in the landing page

<img width="856" alt="whatsIncluded_dashboard" src="https://user-images.githubusercontent.com/101187392/163947724-3bcdf385-80bd-437d-bc44-77dd4835e46e.png">

<img width="850" alt="whatsIncluded_alert_dataSources" src="https://user-images.githubusercontent.com/101187392/163947743-f0e2b068-66b4-432c-9bdc-4de103c97010.png">

